### PR TITLE
Fix MorphTarget slider precision display of dat.gui

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -505,7 +505,7 @@ module.exports = class Viewer {
           this.morphCtrls.push(nameCtrl);
         }
         for (let i = 0; i < mesh.morphTargetInfluences.length; i++) {
-          const ctrl = this.morphFolder.add(mesh.morphTargetInfluences, i, 0, 1).listen();
+          const ctrl = this.morphFolder.add(mesh.morphTargetInfluences, i, 0, 1, 0.01).listen();
           this.morphCtrls.push(ctrl);
         }
       });


### PR DESCRIPTION
This PR fixes MorphTarget slider precision display of dat.gui by passing 5th argument `step`.

jsfiddle example https://jsfiddle.net/3htenq3g/1/

In example, `slider1` represents the current code that precision is 1.0. `slider2` represents this change that precision is 0.01 by explicitly passing `step`. `slider3` is another solution but probably we don't want the default value to be non-zero.

Seems like here is the reason why we need to pass that argument.

https://github.com/dataarts/dat.gui/blob/master/src/dat/controllers/NumberController.js#L48-L59
