### PR TITLE
Fix bug with query-string import

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import { WEBGL } from 'three/examples/jsm/WebGL.js';
 import { Viewer } from './viewer.js';
 import { SimpleDropzone } from 'simple-dropzone';
 import { ValidationController } from './validation-controller.js';
-import { queryString } from 'query-string';
+import queryString from 'query-string';
 
 if (!(window.File && window.FileReader && window.FileList && window.Blob)) {
   console.error('The File APIs are not fully supported in this browser.');


### PR DESCRIPTION
@donmccurdy Currently the application doesn't support using the location hash because of a bad import with the 

```
query-string
```

module. 

<img width="1680" alt="Screen Shot 2020-01-03 at 8 22 37 PM" src="https://user-images.githubusercontent.com/5562156/71757855-2a098e80-2e67-11ea-8687-adbe22244b58.png">

With the import fixed, I can now load from external urls as expected:

<img width="1680" alt="Screen Shot 2020-01-03 at 8 21 43 PM" src="https://user-images.githubusercontent.com/5562156/71757870-40174f00-2e67-11ea-9907-5bf87311f6ca.png">
